### PR TITLE
HEAD methods

### DIFF
--- a/doc_options.go
+++ b/doc_options.go
@@ -18,7 +18,7 @@ type DocOptions struct {
 	NoCache bool
 	// Path the path on which to serve api docs page and spec (defaults to "/docs")
 	Path string
-	// DocIndexPage the name of the docs index page (defaults to "index.htm")
+	// DocIndexPage the name of the docs index page (defaults to "index.html")
 	DocIndexPage string
 	// Title the title in the docs index page (defaults to "API Documentation")
 	Title string
@@ -34,11 +34,13 @@ type DocOptions struct {
 	//
 	// is a map of http status code and response
 	DefaultResponses Responses
+	// HideHeadMethods indicates that all HEAD methods should be hidden from docs
+	HideHeadMethods bool
 }
 
 const (
 	defaultDocsPath  = "/docs"
-	defaultIndexName = "index.htm"
+	defaultIndexName = "index.html"
 	defaultSpecName  = "spec.yaml"
 	defaultTitle     = "API Documentation"
 )

--- a/doc_options_test.go
+++ b/doc_options_test.go
@@ -81,7 +81,7 @@ func TestDocOptions(t *testing.T) {
 	router.ServeHTTP(res, req)
 	assert.Equal(t, http.StatusMovedPermanently, res.Code)
 
-	req, _ = http.NewRequest(http.MethodGet, "/apidocs/index.htm", nil)
+	req, _ = http.NewRequest(http.MethodGet, "/apidocs/index.html", nil)
 	res = httptest.NewRecorder()
 	router.ServeHTTP(res, req)
 	assert.Equal(t, http.StatusOK, res.Code)
@@ -126,7 +126,8 @@ func TestDocOptions_NoCache(t *testing.T) {
 		DocIndexPage: "docs.htm",
 	}
 	router := chi.NewRouter()
-	d.setupRoutes(&apiDef, router)
+	err := d.setupRoutes(&apiDef, router)
+	require.NoError(t, err)
 
 	req, _ := http.NewRequest(http.MethodGet, defaultDocsPath, nil)
 	res := httptest.NewRecorder()

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -15,8 +15,10 @@ func main() {
 }
 
 var myApi = chioas.Definition{
+	AutoHeadMethods: true,
 	DocOptions: chioas.DocOptions{
-		ServeDocs: true,
+		ServeDocs:       true,
+		HideHeadMethods: true,
 	},
 	Paths: map[string]chioas.Path{
 		"/foos": {
@@ -26,6 +28,9 @@ var myApi = chioas.Definition{
 				},
 				http.MethodPost: {
 					Handler: postFoos,
+				},
+				http.MethodHead: {
+					Handler: getFoos,
 				},
 			},
 			Paths: map[string]chioas.Path{

--- a/examples/petstore/api_test.go
+++ b/examples/petstore/api_test.go
@@ -32,9 +32,9 @@ func TestDocs(t *testing.T) {
 	res := httptest.NewRecorder()
 	router.ServeHTTP(res, req)
 	assert.Equal(t, http.StatusMovedPermanently, res.Code)
-	assert.Equal(t, "/docs/index.htm", res.Header().Get("Location"))
+	assert.Equal(t, "/docs/index.html", res.Header().Get("Location"))
 
-	req, _ = http.NewRequest(http.MethodGet, "/docs/index.htm", nil)
+	req, _ = http.NewRequest(http.MethodGet, "/docs/index.html", nil)
 	res = httptest.NewRecorder()
 	router.ServeHTTP(res, req)
 	assert.Equal(t, http.StatusOK, res.Code)


### PR DESCRIPTION
Add support for auto HEAD methods (to automatically add HEAD methods for GET methods where HEAD method not explicitly specified) - see `Definition.AutoHeadMethods` Also:
* added `DocOptions.HideHeadMethods` (to optionally hide HEAD methods from docs)
* added `Method.HideDocs` and `Path.HideDocs` to optionally allow docs for methods/paths to be hidden from docs
* changed default docs page from `index.htm` to `index.html`