### PR TITLE
Add `DocOptions.SupportFilesStripPrefix`

### DIFF
--- a/_examples/petstore/index_template.html
+++ b/_examples/petstore/index_template.html
@@ -1,0 +1,38 @@
+<!-- customized docs html template (to show a logo) - copied from chioas/doc_options.go defaultSwaggerTemplate -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>{{.title}}</title>
+    <meta charset="utf-8" />
+    <link rel="stylesheet" type="text/css" href="./swagger-ui.css" />
+    <link rel="stylesheet" type="text/css" href="./index.css" />
+    <link rel="icon" type="image/png" href="./favicon-32x32.png" sizes="32x32" />
+    <link rel="icon" type="image/png" href="/favicon-16x16.png" sizes="16x16" />
+    <style>{{.stylesOverride}}</style>
+    <style>
+        .logo img {
+            padding: inherit;
+            margin:auto;
+            width: 200px;
+            display: block;
+        }
+    </style>
+</head>
+<body>
+<div class="logo" style="align-content: center">
+    <img src="./petstore-logo.png" alt="pet store logo">
+</div>
+<div id="swagger-ui"></div>
+<script src="./swagger-ui-bundle.js" charset="UTF-8"> </script>
+<script src="./swagger-ui-standalone-preset.js" charset="UTF-8"> </script>
+<script>
+    window.onload = function() {
+        let cfg = {{.swaggeropts}}
+        {{.swaggerpresets}}
+        {{.swaggerplugins}}
+        const ui = SwaggerUIBundle(cfg)
+        window.ui = ui
+    }
+</script>
+</body>
+</html>


### PR DESCRIPTION
Optionally strip path prefix when using `DocOptions.SupportFiles`