### PR TITLE
Optional support for arg type `*multipart.Form`

### DIFF
--- a/typed/arg_types.go
+++ b/typed/arg_types.go
@@ -2,6 +2,7 @@ package typed
 
 import (
 	"github.com/go-andiamo/urit"
+	"mime/multipart"
 	"net/http"
 	"reflect"
 )
@@ -39,3 +40,37 @@ type QueryParams map[string][]string
 
 // RawQuery is a type that can be used as a handler method/func arg to receive request raw query
 type RawQuery string
+
+var multipartFormType = reflect.TypeOf(&multipart.Form{})
+
+// NewMultipartFormArgSupport creates an arg type builder - for use as an option passed to NewTypedMethodsHandlerBuilder(options ...any)
+//
+// By adding this as an option to NewTypedMethodsHandlerBuilder, any typed handler with an arg of type *multipart.Form will be supported
+//
+// If a typed handler has an arg type of *multipart.Form but the request is not `Content-Type=multipart/form-data`, or the request body is nil (or any other error from http.Request.ParseMultipartForm)
+// then the typed handler is not called and an error response of 400 Bad Request is served - unless noAuthError is set, in which case such
+// errors result in a nil *multipart.Form being passed to the typed handler
+func NewMultipartFormArgSupport(maxMemory int64, noAutoError bool) ArgBuilder {
+	return &multipartFormArgBuilder{maxMemory: maxMemory, noAutoError: noAutoError}
+}
+
+type multipartFormArgBuilder struct {
+	maxMemory   int64
+	noAutoError bool
+}
+
+func (ab *multipartFormArgBuilder) IsApplicable(argType reflect.Type, method string, path string) (is bool, readsBody bool) {
+	return argType == multipartFormType, true
+}
+
+func (ab *multipartFormArgBuilder) BuildValue(argType reflect.Type, request *http.Request, params []urit.PathVar) (reflect.Value, error) {
+	err := request.ParseMultipartForm(ab.maxMemory)
+	if err != nil {
+		if ab.noAutoError {
+			var empty *multipart.Form
+			return reflect.ValueOf(empty), nil
+		}
+		return reflect.Value{}, WrapApiError(http.StatusBadRequest, err)
+	}
+	return reflect.ValueOf(request.MultipartForm), nil
+}

--- a/typed/arg_types_test.go
+++ b/typed/arg_types_test.go
@@ -1,0 +1,81 @@
+package typed
+
+import (
+	"github.com/go-andiamo/chioas"
+	"github.com/stretchr/testify/assert"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestMultipartFormArgBuilder(t *testing.T) {
+	var storedForm *multipart.Form
+	called := false
+	mdef := chioas.Method{
+		Handler: func(mf *multipart.Form) {
+			called = true
+			storedForm = mf
+		},
+	}
+	b := NewTypedMethodsHandlerBuilder()
+	_, err := b.BuildHandler("/", http.MethodGet, mdef, nil)
+	assert.Error(t, err)
+	assert.Equal(t, "error building in args (path: /, method: GET) - cannot determine arg 0", err.Error())
+
+	b = NewTypedMethodsHandlerBuilder(NewMultipartFormArgSupport(10000, false))
+	hf, err := b.BuildHandler("/", http.MethodGet, mdef, nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, hf)
+
+	assert.False(t, called)
+	assert.Nil(t, storedForm)
+	req, _ := http.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set(hdrContentType, "multipart/form-data")
+	res := httptest.NewRecorder()
+	hf.ServeHTTP(res, req)
+	assert.Equal(t, http.StatusBadRequest, res.Code)
+	assert.False(t, called)
+
+	b = NewTypedMethodsHandlerBuilder(NewMultipartFormArgSupport(10000, true))
+	hf, err = b.BuildHandler("/", http.MethodGet, mdef, nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, hf)
+	assert.False(t, called)
+	assert.Nil(t, storedForm)
+	req, _ = http.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set(hdrContentType, "multipart/form-data")
+	res = httptest.NewRecorder()
+	hf.ServeHTTP(res, req)
+	assert.Equal(t, http.StatusOK, res.Code)
+	assert.True(t, called)
+	assert.Nil(t, storedForm)
+
+	const bodyForm = `--xxx
+Content-Disposition: form-data; name="field1"
+
+value1
+--xxx
+Content-Disposition: form-data; name="field2"
+
+value2
+--xxx
+Content-Disposition: form-data; name="file"; filename="file"
+Content-Type: application/octet-stream
+Content-Transfer-Encoding: binary
+
+binary data
+--xxx--
+`
+	req, _ = http.NewRequest(http.MethodGet, "/", io.NopCloser(strings.NewReader(bodyForm)))
+	req.Header.Set(hdrContentType, "multipart/form-data; boundary=xxx")
+	res = httptest.NewRecorder()
+	hf.ServeHTTP(res, req)
+	assert.Equal(t, http.StatusOK, res.Code)
+	assert.True(t, called)
+	assert.NotNil(t, storedForm)
+	assert.Equal(t, 2, len(storedForm.Value))
+	assert.Equal(t, 1, len(storedForm.File))
+}

--- a/typed/ins_builder_test.go
+++ b/typed/ins_builder_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-andiamo/urit"
 	"github.com/go-chi/chi/v5"
 	"github.com/stretchr/testify/assert"
+	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -212,6 +213,26 @@ func TestInsBuilder_MakeBuilders(t *testing.T) {
 		{
 			fn:        func(req *http.Request, unknown int) {},
 			expectErr: "cannot determine arg 1",
+		},
+		{
+			fn:        func(res http.Response) {},
+			expectErr: "cannot determine arg 0", // because package http is excluded!
+		},
+		{
+			fn:        func(res *http.Response) {},
+			expectErr: "cannot determine arg 0", // because package http is excluded!
+		},
+		{
+			fn:        func(res []*http.Response) {},
+			expectErr: "cannot determine arg 0", // because package http is excluded!
+		},
+		{
+			fn:        func(mf multipart.Form) {},
+			expectErr: "cannot determine arg 0", // because package multipart is excluded!
+		},
+		{
+			fn:        func(mf *multipart.Form) {},
+			expectErr: "cannot determine arg 0", // because package multipart is excluded!
 		},
 	}
 	for i, tc := range testCases {


### PR DESCRIPTION
Use `NewMultipartFormArgSupport()` as option to `NewTypedMethodsHandlerBuilder()`