### PR TITLE
(bugfix): Fix Ofs.Of generating invalid yaml with Description

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -155,8 +155,8 @@ func (s *Schema) writeYaml(withName bool, w yaml.Writer) {
 }
 
 func (s *Schema) writeOfYaml(w yaml.Writer) {
-	w.WriteTagValue(tags.Description, s.Description).
-		WriteItemStart(tags.Type, defValue(s.Type, values.TypeObject)).
+	w.WriteItemStart(tags.Description, s.Description).
+		WriteTagValue(tags.Type, defValue(s.Type, values.TypeObject)).
 		WriteTagValue(tags.Format, s.Format)
 	if reqs, has := s.getRequiredProperties(); has {
 		w.WriteTagStart(tags.Required)


### PR DESCRIPTION
Having schemas with a `Description` in a `Ofs.Of` field results in an invalid swagger yaml due to copy-paste bug in `writeOfYaml`

```yaml
components:
  schemas: 
    "SomeSchema":
      description: "SomeDescription"
      type: object
      oneOf:
        description: "OneOfDescription1"
        - type: object
          properties:
            "property1":
              type: string
```

```go
func (s *Schema) writeOfYaml(w yaml.Writer) {
	w.WriteTagValue(tags.Description, s.Description).
		WriteItemStart(tags.Type, defValue(s.Type, values.TypeObject)).
		WriteTagValue(tags.Format, s.Format)
```
The fix is to call `WriteItemStart` first, then the `WriteTagValue`:
```go
func (s *Schema) writeOfYaml(w yaml.Writer) {
	w.WriteItemStart(tags.Description, s.Description).
		WriteTagValue(tags.Type, defValue(s.Type, values.TypeObject)).
		WriteTagValue(tags.Format, s.Format)
```
This results in a valid yaml
```yaml
components:
  schemas: 
    "SomeSchema":
      description: "SomeDescription"
      type: object
      oneOf:
        - description: "OneOfDescription1"
          type: object
          properties:
            "property1":
              type: string
```